### PR TITLE
Начальная поддержка для резолва сущностей книг из сервиса рекомендаций

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,10 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
@@ -74,6 +78,18 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.3.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.3.1</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/perflibnetcracker/searchservice/config/RestTemplateConfiguration.java
+++ b/src/main/java/com/perflibnetcracker/searchservice/config/RestTemplateConfiguration.java
@@ -1,0 +1,13 @@
+package com.perflibnetcracker.searchservice.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfiguration {
+    @Bean
+    public RestTemplate getRestTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/perflibnetcracker/searchservice/controller/RecommendResolverController.java
+++ b/src/main/java/com/perflibnetcracker/searchservice/controller/RecommendResolverController.java
@@ -6,6 +6,7 @@ import com.perflibnetcracker.searchservice.service.RecommendService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -30,8 +31,8 @@ public class RecommendResolverController {
                 : recommendService.getPopularBooks();
     }
 
-    @GetMapping("${spring.urlmap}/recommend/{user-id}")
-    public List<Book> getRecommends(String userId) throws ServiceEmptyResultException {
+    @GetMapping("${spring.urlmap}/recommend/{userId}")
+    public List<Book> getRecommends(@PathVariable String userId) throws ServiceEmptyResultException {
         return recommendService.getUserBooks(userId);
     }
 }

--- a/src/main/java/com/perflibnetcracker/searchservice/controller/RecommendResolverController.java
+++ b/src/main/java/com/perflibnetcracker/searchservice/controller/RecommendResolverController.java
@@ -1,0 +1,37 @@
+package com.perflibnetcracker.searchservice.controller;
+
+import com.perflibnetcracker.searchservice.exception.ServiceEmptyResultException;
+import com.perflibnetcracker.searchservice.model.Book;
+import com.perflibnetcracker.searchservice.service.RecommendService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import static java.util.Objects.nonNull;
+
+@RestController
+@CrossOrigin(origins = "${spring.frontend.url}")
+public class RecommendResolverController {
+    private final RecommendService recommendService;
+
+    @Autowired
+    public RecommendResolverController(RecommendService recommendService) {
+        this.recommendService = recommendService;
+    }
+
+    @GetMapping("${spring.urlmap}/recommend/popular")
+    public List<Book> getPopularBooks(@RequestParam(required = false) String number) throws ServiceEmptyResultException {
+        return nonNull(number)
+                ? recommendService.getPopularBooks(number)
+                : recommendService.getPopularBooks();
+    }
+
+    @GetMapping("${spring.urlmap}/recommend/{user-id}")
+    public List<Book> getRecommends(String userId) throws ServiceEmptyResultException {
+        return recommendService.getUserBooks(userId);
+    }
+}

--- a/src/main/java/com/perflibnetcracker/searchservice/controller/SearchController.java
+++ b/src/main/java/com/perflibnetcracker/searchservice/controller/SearchController.java
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
-// TODO: Все ROOT URL сделать по одной переменной (как в маппингах)
 @RestController
 @CrossOrigin(origins = "${spring.frontend.url}")
 public class SearchController {
@@ -56,7 +55,7 @@ public class SearchController {
         return new ResponseEntity<>(book, HttpStatus.OK);
     }
 
-    @GetMapping("/api/service/search/book-delete/{id}")
+    @GetMapping("${spring.urlmap}/book-delete/{id}")
     public String deleteBook(@PathVariable("id") Long id) {
         bookService.deleteById(id);
         return "redirect:/api/service/search/find-all";

--- a/src/main/java/com/perflibnetcracker/searchservice/dto/RecommendFeedbackItemDTO.java
+++ b/src/main/java/com/perflibnetcracker/searchservice/dto/RecommendFeedbackItemDTO.java
@@ -1,0 +1,18 @@
+package com.perflibnetcracker.searchservice.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Data
+@NoArgsConstructor
+public class RecommendFeedbackItemDTO implements Serializable {
+    @JsonProperty("ItemId")
+    private String itemId;
+    @JsonProperty("UserId")
+    private String userId;
+    @JsonProperty("Feedback")
+    private float feedback;
+}

--- a/src/main/java/com/perflibnetcracker/searchservice/dto/RecommendReceivingItemDTO.java
+++ b/src/main/java/com/perflibnetcracker/searchservice/dto/RecommendReceivingItemDTO.java
@@ -1,0 +1,20 @@
+package com.perflibnetcracker.searchservice.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Data
+@NoArgsConstructor
+public class RecommendReceivingItemDTO implements Serializable {
+    @JsonProperty("ItemId")
+    private String itemId;
+    @JsonProperty("Popularity")
+    private Integer popularity;
+    @JsonProperty("Timestamp")
+    private String timestamp;
+    @JsonProperty("Score")
+    private Integer score;
+}

--- a/src/main/java/com/perflibnetcracker/searchservice/exception/ServiceEmptyResultException.java
+++ b/src/main/java/com/perflibnetcracker/searchservice/exception/ServiceEmptyResultException.java
@@ -1,0 +1,10 @@
+package com.perflibnetcracker.searchservice.exception;
+
+public class ServiceEmptyResultException extends Exception {
+    public ServiceEmptyResultException() {
+    }
+
+    public ServiceEmptyResultException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/perflibnetcracker/searchservice/repository/BookRepository.java
+++ b/src/main/java/com/perflibnetcracker/searchservice/repository/BookRepository.java
@@ -3,6 +3,9 @@ package com.perflibnetcracker.searchservice.repository;
 import com.perflibnetcracker.searchservice.model.Book;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 
 public interface BookRepository extends JpaRepository<Book, Long> {
+    List<Book> findBookByIdIn(List<Long> ids);
 }

--- a/src/main/java/com/perflibnetcracker/searchservice/service/RecommendService.java
+++ b/src/main/java/com/perflibnetcracker/searchservice/service/RecommendService.java
@@ -1,0 +1,14 @@
+package com.perflibnetcracker.searchservice.service;
+
+import com.perflibnetcracker.searchservice.exception.ServiceEmptyResultException;
+import com.perflibnetcracker.searchservice.model.Book;
+
+import java.util.List;
+
+public interface RecommendService {
+    List<Book> getPopularBooks(String amount) throws ServiceEmptyResultException;
+
+    List<Book> getPopularBooks() throws ServiceEmptyResultException;
+
+    List<Book> getUserBooks(String userId) throws ServiceEmptyResultException;
+}

--- a/src/main/java/com/perflibnetcracker/searchservice/service/implementation/RecommendServiceImpl.java
+++ b/src/main/java/com/perflibnetcracker/searchservice/service/implementation/RecommendServiceImpl.java
@@ -1,0 +1,83 @@
+package com.perflibnetcracker.searchservice.service.implementation;
+
+import com.perflibnetcracker.searchservice.dto.RecommendReceivingItemDTO;
+import com.perflibnetcracker.searchservice.exception.ServiceEmptyResultException;
+import com.perflibnetcracker.searchservice.model.Book;
+import com.perflibnetcracker.searchservice.repository.BookRepository;
+import com.perflibnetcracker.searchservice.service.RecommendService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.isNull;
+
+@Service
+public class RecommendServiceImpl implements RecommendService {
+    @Value("${spring.recommend.url}")
+    private String recommendServiceUrl;
+
+    private final RestTemplate restTemplate;
+    private final BookRepository bookRepository;
+
+    @Autowired
+    public RecommendServiceImpl(RestTemplate restTemplate, BookRepository bookRepository) {
+        this.restTemplate = restTemplate;
+        this.bookRepository = bookRepository;
+    }
+
+    @Override
+    public List<Book> getPopularBooks() throws ServiceEmptyResultException {
+        ResponseEntity<List<RecommendReceivingItemDTO>> response =
+                restTemplate.exchange(
+                        recommendServiceUrl + "/popular",
+                        HttpMethod.GET,
+                        null,
+                        new ParameterizedTypeReference<>() {
+                        });
+        return getBooksByResponseDtos(response);
+    }
+
+    @Override
+    public List<Book> getUserBooks(String userId) throws ServiceEmptyResultException {
+        ResponseEntity<List<RecommendReceivingItemDTO>> response =
+                restTemplate.exchange(
+                        recommendServiceUrl + "/recommends/" + userId,
+                        HttpMethod.GET,
+                        null,
+                        new ParameterizedTypeReference<>() {
+                        });
+        return getBooksByResponseDtos(response);
+    }
+
+    @Override
+    public List<Book> getPopularBooks(String amount) throws ServiceEmptyResultException {
+        ResponseEntity<List<RecommendReceivingItemDTO>> response =
+                restTemplate.exchange(
+                        recommendServiceUrl + "/popular?number={number}",
+                        HttpMethod.GET,
+                        null,
+                        new ParameterizedTypeReference<>() {
+                        },
+                        amount);
+        return getBooksByResponseDtos(response);
+    }
+
+    private List<Book> getBooksByResponseDtos(ResponseEntity<List<RecommendReceivingItemDTO>> response) throws ServiceEmptyResultException {
+        List<RecommendReceivingItemDTO> result = response.getBody();
+        if (isNull(result)) {
+            throw new ServiceEmptyResultException("Recommend service didn't return body");
+        }
+        List<Long> bookIds = result
+                .stream()
+                .map(dto -> Long.parseLong(dto.getItemId()))
+                .collect(Collectors.toList());
+        return bookRepository.findBookByIdIn(bookIds);
+    }
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -4,3 +4,4 @@ spring.flyway.url=jdbc:postgresql://${PERFLIB_DATABASE_URL:localhost:5432/spring
 server.port=8081
 spring.frontend.url=${PERFLIB_FRONTEND_URL:http://localhost:4200}
 spring.urlmap=${PERFLIB_API_URLMAP:/api/service/search}
+spring.recommend.url=${PERFLIB_RECOMMEND_URL:http://localhost:8050}

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -4,3 +4,4 @@ spring.flyway.url=jdbc:postgresql://${PERFLIB_DATABASE_URL:postgresql:5432/sprin
 server.port=8081
 spring.frontend.url=${PERFLIB_FRONTEND_URL:http://frontend}
 spring.urlmap=${PERFLIB_API_URLMAP:}
+spring.recommend.url=${PERFLIB_RECOMMEND_URL:http://recommend:8081}

--- a/src/test/java/com/perflibnetcracker/searchservice/SearchServiceApplicationTests.java
+++ b/src/test/java/com/perflibnetcracker/searchservice/SearchServiceApplicationTests.java
@@ -1,11 +1,14 @@
 package com.perflibnetcracker.searchservice;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest
 class SearchServiceApplicationTests {
+    @Test
+    public void test() {
+        assertTrue(true);
+    }
 }

--- a/src/test/java/com/perflibnetcracker/searchservice/service/RecommendServiceTest.java
+++ b/src/test/java/com/perflibnetcracker/searchservice/service/RecommendServiceTest.java
@@ -1,0 +1,31 @@
+package com.perflibnetcracker.searchservice.service;
+
+import com.perflibnetcracker.searchservice.exception.ServiceEmptyResultException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static java.util.Objects.isNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Данный тест работает только в том случае, если сервис рекомендаций имеет как минимум двух пользователей
+ * И пользователи сделали хоть какой то фидбек
+ */
+@SpringBootTest
+public class RecommendServiceTest {
+    @Autowired
+    private RecommendService recommendService;
+
+    // Если тест выдаёт http error: unexpected end of JSON input - сервис рекомендаций пустой, нужен фидбек
+    @Test
+    public void testPopular() throws ServiceEmptyResultException {
+        assertFalse(isNull(recommendService.getPopularBooks("1")));
+        assertFalse(isNull(recommendService.getPopularBooks()));
+    }
+
+    @Test
+    public void testRecommends() throws ServiceEmptyResultException {
+        assertFalse(isNull(recommendService.getUserBooks("2")));
+    }
+}


### PR DESCRIPTION
Fixes #2 
 Поправил в контроллере поиска один маппинг
 Добавил контроллер и сервисы для общения с микросервисом рекомендаций (для резолва сущностей книг)
 Убрал TODO для ROOT URL
 Добавил пару тестов для проверки сервиса рекомендаций (требует предварительного фидбека, см. https://github.com/PerfLibNetcracker/gorse/blob/master/bin/recommends_feedback.json )